### PR TITLE
fix warnings

### DIFF
--- a/src/Node/FS/Aff/Mkdirp.purs
+++ b/src/Node/FS/Aff/Mkdirp.purs
@@ -2,12 +2,10 @@ module Node.FS.Aff.Mkdirp (mkdirp) where
 
 import Prelude
 
-import Data.Either (Either(..))
-import Effect.Aff (Aff, catchError, throwError, try)
+import Effect.Aff (Aff, catchError)
 import Effect.Class (liftEffect)
 import Effect.Exception (Error)
-import Node.FS.Aff (mkdir, stat)
-import Node.FS.Stats (isDirectory)
+import Node.FS.Aff (mkdir)
 import Node.Path (FilePath, dirname, resolve)
 
 foreign import isENOENT :: Error -> Boolean


### PR DESCRIPTION
```
[1/7 UnusedImport] .spago/mkdirp-aff/master/src/Node/FS/Aff/Mkdirp.purs:5:1
  5  import Data.Either (Either(..))
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  The import of Data.Either is redundant
[2/7 UnusedExplicitImport] .spago/mkdirp-aff/master/src/Node/FS/Aff/Mkdirp.purs:6:1
  6  import Effect.Aff (Aff, catchError, throwError, try)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  The import of module Effect.Aff contains the following unused references:
  
    throwError
    try
  
  It could be replaced with:
  
    import Effect.Aff (Aff, catchError)
[3/7 UnusedExplicitImport] .spago/mkdirp-aff/master/src/Node/FS/Aff/Mkdirp.purs:9:1
  9  import Node.FS.Aff (mkdir, stat)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  The import of module Node.FS.Aff contains the following unused references:
  
    stat
  
  It could be replaced with:
  
    import Node.FS.Aff (mkdir)
[4/7 UnusedImport] .spago/mkdirp-aff/master/src/Node/FS/Aff/Mkdirp.purs:10:1
  10  import Node.FS.Stats (isDirectory)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  The import of Node.FS.Stats is redundant
```